### PR TITLE
feat: configurable keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,20 @@ plugins {
 
 https://zellij.dev/documentation/plugin-aliases
 
-then set a keybind to launch it in a floating window:
+You can also configure the keybindings within the plugin:
+
+```kdl
+plugins {
+  zj-quit location="file:/path/to/zj-quit.wasm" {
+    confirm_key "q"
+    cancel_key "Esc"
+  }
+}
+```
+
+Keys are referenced from: [zellij doc](https://docs.rs/zellij-tile/latest/zellij_tile/prelude/enum.Key.html)
+
+Then set a keybind to launch it in a floating window:
 
 ```kdl
 keybinds clear-defaults=true {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,14 @@ use std::collections::BTreeMap;
 
 struct State {
     confirm_key: Key,
-    abort_key: Key,
+    cancel_key: Key,
 }
 
 impl Default for State {
     fn default() -> Self {
         Self {
             confirm_key: Key::Char('\n'),
-            abort_key: Key::Esc,
+            cancel_key: Key::Esc,
         }
     }
 }
@@ -26,8 +26,8 @@ impl ZellijPlugin for State {
         if let Some(confirm_key) = configuration.get("confirm_key") {
             self.confirm_key = confirm_key.parse().unwrap_or(self.confirm_key);
         }
-        if let Some(abort_key) = configuration.get("abort_key") {
-            self.abort_key = abort_key.parse().unwrap_or(self.abort_key);
+        if let Some(abort_key) = configuration.get("cancel_key") {
+            self.cancel_key = abort_key.parse().unwrap_or(self.cancel_key);
         }
     }
 
@@ -36,7 +36,7 @@ impl ZellijPlugin for State {
             Event::Key(key) => {
                 if self.confirm_key == key {
                     quit_zellij()
-                } else if self.abort_key == key {
+                } else if self.cancel_key == key {
                     hide_self();
                 }
             }
@@ -61,13 +61,13 @@ impl ZellijPlugin for State {
         let help_text = format!(
             "Help: <{}> - Confirm, <{}> - Cancel",
             key_name(self.confirm_key),
-            key_name(self.abort_key),
+            key_name(self.cancel_key),
         );
         let help_text_y_location = rows - 1;
         let help_text_x_location = cols.saturating_sub(help_text.chars().count()) / 2;
 
         let confirm_key_length = key_name(self.confirm_key).chars().count();
-        let abort_key_length = key_name(self.abort_key).chars().count();
+        let abort_key_length = key_name(self.cancel_key).chars().count();
 
         print_text_with_coordinates(
             Text::new(help_text)

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,18 +58,35 @@ impl ZellijPlugin for State {
             None,
         );
 
-        let help_text = "Help: <ENTER> - Confirm, <ESC> - Cancel";
+        let help_text = format!(
+            "Help: <{}> - Confirm, <{}> - Cancel",
+            key_name(self.confirm_key),
+            key_name(self.abort_key),
+        );
         let help_text_y_location = rows - 1;
         let help_text_x_location = cols.saturating_sub(help_text.chars().count()) / 2;
 
+        let confirm_key_length = key_name(self.confirm_key).chars().count();
+        let abort_key_length = key_name(self.abort_key).chars().count();
+
         print_text_with_coordinates(
             Text::new(help_text)
-                .color_range(3, 6..13)
-                .color_range(3, 25..30),
+                .color_range(3, 6..8 + confirm_key_length)
+                .color_range(
+                    3,
+                    20 + confirm_key_length..22 + confirm_key_length + abort_key_length,
+                ),
             help_text_x_location,
             help_text_y_location,
             None,
             None,
         );
+    }
+}
+
+fn key_name(key: Key) -> String {
+    match key {
+        Key::Char('\n') => "Enter".to_owned(),
+        _ => key.to_string(),
     }
 }


### PR DESCRIPTION
Hi and first of all thanks for your great plugin! I really like it!

Since I like to use letter keys more for my shortcuts, I implemented the ability to configure them on your own. It defaults to your default configuration in case no keybindings are specified.

The configuration would look like:

```javascript
zj-quit location="file:${pkgs.zj-quit}/bin/zj-quit.wasm" {
  confirm_key "q"
  abort_key "Esc"
}
```

Feel free to add comments or reject this pull request, in case you don't want this functionality or something is missing.